### PR TITLE
Give users a "start from scratch" option if they aren't in a good place.

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -33,6 +33,10 @@
       <p class="not-logged-in-instructions hidden">
         Please log in to Drupal.org.
       </p>
+      <p class="start-from-scratch hidden">
+        Or start with a <a href="https://gitpod.io/#DDEV_REPO=https%3A%2F%2Fgithub.com%2Fddev%2Fd10simple,DDEV_ARTIFACTS=https%3A%2F%2Fgithub.com%2Fddev%2Fd10simple-artifacts/https://github.com/ddev/ddev-gitpod-launcher/
+        ">clean Drupal install</a>.
+      </p>
     </div>
     <hr>
     <form class="form-selection hidden" id="form-selection" aria-live="polite">

--- a/scripts/popup.js
+++ b/scripts/popup.js
@@ -192,6 +192,10 @@ function displayWarning(className) {
     // Reveal error message
     const warningMessageElement = document.querySelector('.' + className);
     warningMessageElement.classList.remove('hidden');
+
+    // Also reveal "start from scratch" message on any warning.
+    const startFromScratchElement = document.querySelector('.start-from-scratch');
+    startFromScratchElement.classList.remove('hidden');
 }
 
 function populateSelectList(id, options) {


### PR DESCRIPTION
Should add a new message that leverages [DDEV GitPod Launcher](https://ddev.github.io/ddev-gitpod-launcher/) to spin up a fresh Drupal install if the user isn't on an issue page or has another issue that might prevent them from opening DrupalPod.

fixes https://github.com/shaal/DrupalPod/issues/116