### PR TITLE
Fix error in Safari

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -23,7 +23,8 @@
         "https://*.gitpod.io/*"
     ],
     "background": {
-        "scripts": ["scripts/background.js"]
+        "scripts": ["scripts/background.js"],
+        "service_worker": "scripts/background.js"
     },
     "content_scripts": [
         {


### PR DESCRIPTION
Safari on iOS requires `"persistent": false` to be set on background scripts. However, that is not allowed in Manifest V3 on Chrome. So it is necessary to have both service_worker and scripts properties for the extension to work in all browsers.